### PR TITLE
Homework 8

### DIFF
--- a/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
@@ -10,9 +10,22 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "app", ignoreUnknownFields = false)
 public record ApplicationConfig(
     @NotEmpty
-    String telegramToken
+    String telegramToken,
+    KafkaConfigurationProperties kafkaConfigurationProperties
 ) {
     @Bean TelegramBot telegramBot() {
         return new TelegramBot(telegramToken);
+    }
+
+    public record KafkaConfigurationProperties(
+        String bootstrapServers,
+        UpdatesTopic updatesTopic
+    ) {
+        public record UpdatesTopic(
+            String name,
+            Integer partitions,
+            Integer replicas
+        ) {
+        }
     }
 }

--- a/bot/src/main/java/edu/java/bot/configuration/KafkaConfiguration.java
+++ b/bot/src/main/java/edu/java/bot/configuration/KafkaConfiguration.java
@@ -1,0 +1,90 @@
+package edu.java.bot.configuration;
+
+import edu.java.dto.bot.LinkUpdate;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+@EnableKafka
+public class KafkaConfiguration {
+    private final ApplicationConfig applicationConfig;
+
+    public KafkaConfiguration(ApplicationConfig applicationConfig) {
+        this.applicationConfig = applicationConfig;
+    }
+
+    @Bean
+    public NewTopic topic() {
+        return TopicBuilder
+            .name(applicationConfig.kafkaConfigurationProperties().updatesTopic().name())
+            .partitions(applicationConfig.kafkaConfigurationProperties().updatesTopic().partitions())
+            .replicas(applicationConfig.kafkaConfigurationProperties().updatesTopic().replicas())
+            .build();
+    }
+
+    @Bean
+    public ProducerFactory<Long, LinkUpdate> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerProps());
+    }
+
+    private Map<String, Object> producerProps() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            applicationConfig.kafkaConfigurationProperties().bootstrapServers()
+        );
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return props;
+    }
+
+    @Bean
+    public ConsumerFactory<Long, LinkUpdate> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerProps());
+    }
+
+    private Map<String, Object> consumerProps() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            applicationConfig.kafkaConfigurationProperties().bootstrapServers()
+        );
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, LinkUpdate.class);
+        return props;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<Long, LinkUpdate>
+    kafkaListenerContainerFactory(ConsumerFactory<Long, LinkUpdate> consumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<Long, LinkUpdate> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        return factory;
+    }
+
+    @Bean
+    public KafkaTemplate<Long, LinkUpdate> kafkaTemplate(ProducerFactory<Long, LinkUpdate> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+}

--- a/bot/src/main/java/edu/java/bot/controller/BotController.java
+++ b/bot/src/main/java/edu/java/bot/controller/BotController.java
@@ -1,6 +1,6 @@
 package edu.java.bot.controller;
 
-import edu.java.bot.service.SendMessageService;
+import edu.java.bot.service.LinkUpdateService;
 import edu.java.dto.bot.LinkUpdate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -13,18 +13,16 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class BotController {
 
-    private final SendMessageService sendMessageService;
+    private final LinkUpdateService linkUpdateService;
 
-    public BotController(SendMessageService sendMessageService) {
-        this.sendMessageService = sendMessageService;
+    public BotController(LinkUpdateService linkUpdateService) {
+        this.linkUpdateService = linkUpdateService;
     }
 
     @PostMapping(consumes = "application/json", value = "/updates")
     @ResponseStatus(HttpStatus.OK)
     public void sendResponse(@RequestBody LinkUpdate linkUpdate) {
         log.info("Отправка обновления на обработку");
-        for (Long telegramChatId : linkUpdate.getTgChatIds()) {
-            sendMessageService.sendLinkUpdateMessage(telegramChatId, linkUpdate.getUrl(), linkUpdate.getDescription());
-        }
+        linkUpdateService.sendNotification(linkUpdate);
     }
 }

--- a/bot/src/main/java/edu/java/bot/listener/kafka/ScrapperNotificationConsumer.java
+++ b/bot/src/main/java/edu/java/bot/listener/kafka/ScrapperNotificationConsumer.java
@@ -1,0 +1,35 @@
+package edu.java.bot.listener.kafka;
+
+import edu.java.bot.configuration.ApplicationConfig;
+import edu.java.bot.service.LinkUpdateService;
+import edu.java.dto.bot.LinkUpdate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapperNotificationConsumer {
+
+    private final ApplicationConfig applicationConfig;
+
+    private final LinkUpdateService linkUpdateService;
+
+    private final KafkaTemplate<Long, LinkUpdate> kafkaTemplate;
+
+    @KafkaListener(groupId = "scrapper.updates.listeners",
+                   topics = "${app.kafka-configuration-properties.updates-topic.name}",
+                   containerFactory = "kafkaListenerContainerFactory")
+    public void listen(LinkUpdate linkUpdate) {
+        try {
+            linkUpdateService.sendNotification(linkUpdate);
+        } catch (Exception e) {
+            kafkaTemplate.send(
+                applicationConfig.kafkaConfigurationProperties().updatesTopic().name() + "_dlq",
+                linkUpdate.getId(),
+                linkUpdate
+            );
+        }
+    }
+}

--- a/bot/src/main/java/edu/java/bot/service/LinkUpdateService.java
+++ b/bot/src/main/java/edu/java/bot/service/LinkUpdateService.java
@@ -1,0 +1,22 @@
+package edu.java.bot.service;
+
+import edu.java.dto.bot.LinkUpdate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LinkUpdateService {
+    private final SendMessageService sendMessageService;
+
+    public void sendNotification(LinkUpdate linkUpdate) {
+        List<Long> tgChatIds = linkUpdate.getTgChatIds();
+        if (tgChatIds.isEmpty()) {
+            throw new IllegalStateException();
+        }
+        for (Long telegramChatId : linkUpdate.getTgChatIds()) {
+            sendMessageService.sendLinkUpdateMessage(telegramChatId, linkUpdate.getUrl(), linkUpdate.getDescription());
+        }
+    }
+}

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -1,5 +1,11 @@
 app:
   telegram-token: ${TELEGRAM_TOKEN}
+  kafka-configuration-properties:
+    bootstrap-servers: 127.0.0.1:9092,127.0.0.1:9093,127.0.0.1:9094
+    updates-topic:
+      name: queuing.updates.send
+      partitions: 2
+      replicas: 2
 
 spring:
   application:
@@ -15,6 +21,9 @@ spring:
       - rate-limit-buckets-bot
     caffeine:
       spec: maximumSize=100000,expireAfterAccess=60s
+  kafka:
+    consumer:
+      auto-offset-reset: earliest
 
 bucket4j:
   enabled: true

--- a/compose.yml
+++ b/compose.yml
@@ -28,8 +28,99 @@ services:
     networks:
       - backend
 
+  zoo1:
+    image: confluentinc/cp-zookeeper:7.3.2
+    hostname: zoo1
+    container_name: zoo1
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_SERVERS: zoo1:2888:3888
+    volumes:
+      - zoo1:/var/lib/zookeeper
+    networks:
+      - backend
+
+  kafka1:
+    image: confluentinc/cp-kafka:7.3.2
+    hostname: kafka1
+    container_name: kafka1
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:19092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092,DOCKER://host.docker.internal:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
+      KAFKA_BROKER_ID: 1
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1
+    volumes:
+      - kafka1:/var/lib/kafka
+    networks:
+      - backend
+
+
+  kafka2:
+    image: confluentinc/cp-kafka:7.3.2
+    hostname: kafka2
+    container_name: kafka2
+    ports:
+      - "9093:9093"
+      - "29093:29093"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka2:19093,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9093,DOCKER://host.docker.internal:29093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
+      KAFKA_BROKER_ID: 2
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1
+    volumes:
+      - kafka2:/var/lib/kafka
+    networks:
+      - backend
+
+
+  kafka3:
+    image: confluentinc/cp-kafka:7.3.2
+    hostname: kafka3
+    container_name: kafka3
+    ports:
+      - "9094:9094"
+      - "29094:29094"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka3:19094,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094,DOCKER://host.docker.internal:29094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
+      KAFKA_BROKER_ID: 3
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1
+    volumes:
+      - kafka3:/var/lib/kafka
+    networks:
+      - backend
+
+
 volumes:
   postgresql: { }
+  zoo1: { }
+  kafka1: { }
+  kafka2: { }
+  kafka3: { }
 
 networks:
   backend: { }

--- a/scrapper/src/main/java/edu/java/configuration/ApplicationConfig.java
+++ b/scrapper/src/main/java/edu/java/configuration/ApplicationConfig.java
@@ -12,9 +12,23 @@ public record ApplicationConfig(
     @NotNull
     @Bean
     Scheduler scheduler,
-    AccessType databaseAccessType
+    AccessType databaseAccessType,
+    KafkaConfigurationProperties kafkaConfigurationProperties,
+    boolean useQueue
 ) {
     public record Scheduler(boolean enable, @NotNull Duration interval, @NotNull Duration forceCheckDelay) {
+    }
+
+    public record KafkaConfigurationProperties(
+        String bootstrapServers,
+        UpdatesTopic updatesTopic
+    ) {
+        public record UpdatesTopic(
+            String name,
+            Integer partitions,
+            Integer replicas
+        ) {
+        }
     }
 
     public enum AccessType {

--- a/scrapper/src/main/java/edu/java/configuration/ClientConfiguration.java
+++ b/scrapper/src/main/java/edu/java/configuration/ClientConfiguration.java
@@ -1,6 +1,5 @@
 package edu.java.configuration;
 
-import edu.java.client.BotClient;
 import edu.java.client.github.impl.GithubClientImpl;
 import edu.java.client.stackoverflow.impl.StackOverflowClientImpl;
 import edu.java.service.GithubRepoService;
@@ -41,10 +40,5 @@ public class ClientConfiguration {
             stackOverflowQuestionService,
             retryConfig
         );
-    }
-
-    @Bean
-    public BotClient botClient(@Value("http://localhost:8090") String baseUrl) {
-        return new BotClient(WebClient.builder().baseUrl(baseUrl).build(), retryConfig);
     }
 }

--- a/scrapper/src/main/java/edu/java/configuration/KafkaConfiguration.java
+++ b/scrapper/src/main/java/edu/java/configuration/KafkaConfiguration.java
@@ -1,0 +1,65 @@
+package edu.java.configuration;
+
+import edu.java.dto.bot.LinkUpdate;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaConfiguration {
+
+    private final ApplicationConfig applicationConfig;
+
+    public KafkaConfiguration(ApplicationConfig applicationConfig) {
+        this.applicationConfig = applicationConfig;
+    }
+
+    @Bean
+    public NewTopic topic() {
+        return TopicBuilder
+            .name(applicationConfig.kafkaConfigurationProperties().updatesTopic().name())
+            .partitions(applicationConfig.kafkaConfigurationProperties().updatesTopic().partitions())
+            .replicas(applicationConfig.kafkaConfigurationProperties().updatesTopic().replicas())
+            .build();
+    }
+
+    @Bean
+    public NewTopic dlqTopic() {
+        return TopicBuilder
+            .name(applicationConfig.kafkaConfigurationProperties().updatesTopic().name() + "_dlq")
+            .partitions(applicationConfig.kafkaConfigurationProperties().updatesTopic().partitions())
+            .replicas(applicationConfig.kafkaConfigurationProperties().updatesTopic().replicas())
+            .build();
+    }
+
+    @Bean
+    public ProducerFactory<Long, LinkUpdate> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(senderProps());
+    }
+
+    private Map<String, Object> senderProps() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            applicationConfig.kafkaConfigurationProperties().bootstrapServers()
+        );
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        return props;
+    }
+
+    @Bean
+    public KafkaTemplate<Long, LinkUpdate> kafkaTemplate(ProducerFactory<Long, LinkUpdate> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+}

--- a/scrapper/src/main/java/edu/java/configuration/NotificationSendingConfiguration.java
+++ b/scrapper/src/main/java/edu/java/configuration/NotificationSendingConfiguration.java
@@ -1,0 +1,33 @@
+package edu.java.configuration;
+
+import edu.java.dto.bot.LinkUpdate;
+import edu.java.service.NotificationSendingService;
+import edu.java.service.notificationsender.http.BotClient;
+import edu.java.service.notificationsender.kafka.ScrapperQueueProducer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class NotificationSendingConfiguration {
+    @Bean
+    @ConditionalOnProperty(prefix = "app", name = "use-queue", havingValue = "true")
+    public NotificationSendingService scrapperQueueProducer(
+        ApplicationConfig applicationConfig,
+        KafkaTemplate<Long, LinkUpdate> kafkaTemplate
+    ) {
+        return new ScrapperQueueProducer(applicationConfig, kafkaTemplate);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "app", name = "use-queue", havingValue = "false")
+    public NotificationSendingService botClient(
+        @Value("http://localhost:8090") String baseUrl,
+        RetryConfig retryConfig
+    ) {
+        return new BotClient(WebClient.builder().baseUrl(baseUrl).build(), retryConfig);
+    }
+}

--- a/scrapper/src/main/java/edu/java/service/NotificationSendingService.java
+++ b/scrapper/src/main/java/edu/java/service/NotificationSendingService.java
@@ -1,0 +1,7 @@
+package edu.java.service;
+
+import edu.java.dto.bot.LinkUpdate;
+
+public interface NotificationSendingService {
+    void send(LinkUpdate update);
+}

--- a/scrapper/src/main/java/edu/java/service/notificationsender/http/BotClient.java
+++ b/scrapper/src/main/java/edu/java/service/notificationsender/http/BotClient.java
@@ -1,15 +1,16 @@
-package edu.java.client;
+package edu.java.service.notificationsender.http;
 
 import edu.java.configuration.RetryConfig;
 import edu.java.dto.bot.LinkUpdate;
 import edu.java.dto.scrapper.response.LinkResponse;
 import edu.java.exception.handler.ApiErrorResponse;
+import edu.java.service.NotificationSendingService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @Slf4j
-public class BotClient {
+public class BotClient implements NotificationSendingService {
     private final WebClient webClient;
 
     private final RetryConfig retryConfig;
@@ -19,7 +20,8 @@ public class BotClient {
         this.retryConfig = retryConfig;
     }
 
-    public void sendUpdate(LinkUpdate linkUpdate) {
+    @Override
+    public void send(LinkUpdate linkUpdate) {
         webClient
             .post()
             .uri("/updates")

--- a/scrapper/src/main/java/edu/java/service/notificationsender/kafka/ScrapperQueueProducer.java
+++ b/scrapper/src/main/java/edu/java/service/notificationsender/kafka/ScrapperQueueProducer.java
@@ -1,0 +1,24 @@
+package edu.java.service.notificationsender.kafka;
+
+import edu.java.configuration.ApplicationConfig;
+import edu.java.dto.bot.LinkUpdate;
+import edu.java.service.NotificationSendingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@RequiredArgsConstructor
+public class ScrapperQueueProducer implements NotificationSendingService {
+
+    private final ApplicationConfig applicationConfig;
+
+    private final KafkaTemplate<Long, LinkUpdate> kafkaTemplate;
+
+    @Override
+    public void send(LinkUpdate update) {
+        kafkaTemplate.send(
+            applicationConfig.kafkaConfigurationProperties().updatesTopic().name(),
+            update.getId(),
+            update
+        );
+    }
+}

--- a/scrapper/src/main/java/edu/java/service/updater/LinkUpdaterScheduler.java
+++ b/scrapper/src/main/java/edu/java/service/updater/LinkUpdaterScheduler.java
@@ -1,9 +1,11 @@
-package edu.java.service;
+package edu.java.service.updater;
 
-import edu.java.client.BotClient;
 import edu.java.client.ClientsChain;
 import edu.java.domain.Link;
 import edu.java.dto.bot.LinkUpdate;
+import edu.java.service.LinkService;
+import edu.java.service.NotificationSendingService;
+import edu.java.service.TelegramChatService;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -16,7 +18,7 @@ public class LinkUpdaterScheduler {
 
     private final ClientsChain chain;
 
-    private final BotClient botClient;
+    private final NotificationSendingService notificationSendingService;
 
     private final LinkService linkService;
 
@@ -24,12 +26,12 @@ public class LinkUpdaterScheduler {
 
     public LinkUpdaterScheduler(
         ClientsChain chain,
-        BotClient botClient,
+        NotificationSendingService notificationSendingService,
         LinkService linkService,
         TelegramChatService telegramChatService
     ) {
         this.chain = chain;
-        this.botClient = botClient;
+        this.notificationSendingService = notificationSendingService;
         this.linkService = linkService;
         this.telegramChatService = telegramChatService;
     }
@@ -61,7 +63,7 @@ public class LinkUpdaterScheduler {
                 .description(description)
                 .tgChatIds(telegramChatIds)
                 .build();
-            botClient.sendUpdate(linkUpdate);
+            notificationSendingService.send(linkUpdate);
         }
     }
 }

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -4,6 +4,13 @@ app:
     interval: 10s
     force-check-delay: 10s
   database-access-type: jpa
+  use-queue: false
+  kafka-configuration-properties:
+    bootstrap-servers: 127.0.0.1:9092,127.0.0.1:9093,127.0.0.1:9094
+    updates-topic:
+      name: queuing.updates.send
+      partitions: 2
+      replicas: 2
 
 spring:
   application:
@@ -22,6 +29,9 @@ spring:
       - rate-limit-buckets-scrapper
     caffeine:
       spec: maximumSize=100000,expireAfterAccess=60s
+  kafka:
+    consumer:
+      auto-offset-reset: earliest
 
 bucket4j:
   enabled: true

--- a/scrapper/src/test/java/edu/java/client/BotClientTest.java
+++ b/scrapper/src/test/java/edu/java/client/BotClientTest.java
@@ -5,6 +5,7 @@ import edu.java.dto.bot.LinkUpdate;
 import java.net.URI;
 import java.util.List;
 import edu.java.scrapper.IntegrationTest;
+import edu.java.service.notificationsender.http.BotClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,7 +35,7 @@ class BotClientTest extends IntegrationTest {
         stubFor(post(urlEqualTo("/updates"))
             .willReturn(ok()));
 
-        botClient.sendUpdate(linkUpdate);
+        botClient.send(linkUpdate);
 
         verify(postRequestedFor(urlEqualTo("/updates")));
     }


### PR DESCRIPTION
Добавил в compose.yml новые сервисы на базе [kafka и zookeeper](https://github.com/Prohkit/java-backend-course-2-link-tracker/commit/f2bf2e972c9258f83c1722fd4847525378629bdb).  
Добавил конфигурацию для кафки в [scrapper](https://github.com/Prohkit/java-backend-course-2-link-tracker/commit/d0586d9f23b6bc459bb4c23711aa2a952b5cf621) и в [bot](https://github.com/Prohkit/java-backend-course-2-link-tracker/commit/352b9eb33af50b28cc05a4258e9058f7977d69da). (В названии коммита конфигурации кафки для бота опечатка).  
Написал отдельный [класс-сервис](https://github.com/Prohkit/java-backend-course-2-link-tracker/commit/1d62228b624e0f9696a1944ffad4f52408dbb5b5#diff-c10f88513a3429c978cbe8119889364d941c797c25ee7f1dfc23859d761cd6a1) для отправки сообщений в очередь.  
Сделал [интерфейс](https://github.com/Prohkit/java-backend-course-2-link-tracker/commit/d5ee0ac47c3eb2962c09a457beacfcd1ef1b5f76) отправки уведомлений.  
Добавил [возможность](https://github.com/Prohkit/java-backend-course-2-link-tracker/commit/d54b6851bdfccbdf2e0e3cc7edda0e282b306d7f#diff-8667ba14f47352f182d2caa5247216c7cdac8865188e3ad5cd00a148e603de84) отправки сообщения или в очередь через ScrapperQueueProducer или по HTTP через BotClient в зависимости от поля useQueue.  
Сделал абстракцию обработки уведомлений в виде нового [сервиса](https://github.com/Prohkit/java-backend-course-2-link-tracker/commit/a21569c69c1c6a06fbd12189c40948d6f2d7916d) в боте.  
Создал [обработчик](https://github.com/Prohkit/java-backend-course-2-link-tracker/commit/5d94935bd3b6d9aa3959805201d88bce2452f2cf) обновлений (слушателя очереди).  
В случае, когда нельзя обработать сообщение (к примеру [здесь](https://github.com/Prohkit/java-backend-course-2-link-tracker/commit/a21569c69c1c6a06fbd12189c40948d6f2d7916d), если LinkUpdate пришел без айди телеграм чата), ScrapperNotificationConsumer [отправляет](https://github.com/Prohkit/java-backend-course-2-link-tracker/commit/5d94935bd3b6d9aa3959805201d88bce2452f2cf) его в очередь с суффиксом _dlq.