### PR TITLE
Homework 9 to add_tests

### DIFF
--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -19,6 +19,26 @@
             <version>0.1</version>
         </dependency>
 
+        <!-- Metrics -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+        </dependency>
+
         <!-- Bucket4j -->
         <dependency>
             <groupId>com.giffing.bucket4j.spring.boot.starter</groupId>

--- a/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
@@ -11,7 +11,8 @@ import org.springframework.validation.annotation.Validated;
 public record ApplicationConfig(
     @NotEmpty
     String telegramToken,
-    KafkaConfigurationProperties kafkaConfigurationProperties
+    KafkaConfigurationProperties kafkaConfigurationProperties,
+    Micrometer micrometer
 ) {
     @Bean TelegramBot telegramBot() {
         return new TelegramBot(telegramToken);
@@ -25,6 +26,16 @@ public record ApplicationConfig(
             String name,
             Integer partitions,
             Integer replicas
+        ) {
+        }
+    }
+
+    public record Micrometer(
+        ProcessedMessagesCounter processedMessagesCounter
+    ) {
+        public record ProcessedMessagesCounter(
+            String name,
+            String description
         ) {
         }
     }

--- a/bot/src/main/java/edu/java/bot/configuration/MicrometerConfiguration.java
+++ b/bot/src/main/java/edu/java/bot/configuration/MicrometerConfiguration.java
@@ -1,0 +1,22 @@
+package edu.java.bot.configuration;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MicrometerConfiguration {
+    @Bean
+    public Counter processedMessagesCounter(MeterRegistry registry, ApplicationConfig applicationConfig) {
+        return Counter.builder(applicationConfig
+                .micrometer()
+                .processedMessagesCounter()
+                .name())
+            .description(applicationConfig
+                .micrometer()
+                .processedMessagesCounter()
+                .description())
+            .register(registry);
+    }
+}

--- a/bot/src/main/java/edu/java/bot/service/LinkUpdateService.java
+++ b/bot/src/main/java/edu/java/bot/service/LinkUpdateService.java
@@ -1,6 +1,7 @@
 package edu.java.bot.service;
 
 import edu.java.dto.bot.LinkUpdate;
+import io.micrometer.core.instrument.Counter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class LinkUpdateService {
+    private final Counter processedMessagesCounter;
     private final SendMessageService sendMessageService;
 
     public void sendNotification(LinkUpdate linkUpdate) {
@@ -17,6 +19,7 @@ public class LinkUpdateService {
         }
         for (Long telegramChatId : linkUpdate.getTgChatIds()) {
             sendMessageService.sendLinkUpdateMessage(telegramChatId, linkUpdate.getUrl(), linkUpdate.getDescription());
+            processedMessagesCounter.increment();
         }
     }
 }

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -6,6 +6,10 @@ app:
       name: queuing.updates.send
       partitions: 2
       replicas: 2
+  micrometer:
+    processed-messages-counter:
+      name: messages.processed
+      description: Количество обработанных сообщений
 
 spring:
   application:
@@ -51,3 +55,17 @@ server:
 
 logging:
   config: classpath:log4j2-plain.xml
+
+management:
+  server:
+    port: 8091
+  endpoints:
+    web:
+      base-path: /
+      exposure:
+        include: health,info,prometheus
+      path-mapping:
+        prometheus: metrics
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/bot/src/test/java/edu/java/bot/service/LinkUpdateServiceTest.java
+++ b/bot/src/test/java/edu/java/bot/service/LinkUpdateServiceTest.java
@@ -1,6 +1,7 @@
 package edu.java.bot.service;
 
 import edu.java.dto.bot.LinkUpdate;
+import io.micrometer.core.instrument.Counter;
 import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,9 @@ import static org.mockito.Mockito.verify;
 class LinkUpdateServiceTest {
     @InjectMocks
     private LinkUpdateService linkUpdateService;
+
+    @Mock
+    private Counter processedMessagesCounter;
 
     @Mock
     private SendMessageService sendMessageService;

--- a/compose.yml
+++ b/compose.yml
@@ -114,6 +114,31 @@ services:
     networks:
       - backend
 
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    hostname: prometheus
+    volumes:
+      - ./prometheus.yml:/prometheus/prometheus.yml
+      - prometheus:/prometheus
+    command:
+      - --config.file=/prometheus/prometheus.yml
+    restart: unless-stopped
+    networks:
+      - backend
+
+  grafana:
+    image: grafana/grafana-oss
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana:/var/lib/grafana
+    restart: unless-stopped
+    networks:
+      - backend
 
 volumes:
   postgresql: { }
@@ -121,6 +146,8 @@ volumes:
   kafka1: { }
   kafka2: { }
   kafka3: { }
+  prometheus: { }
+  grafana: { }
 
 networks:
   backend: { }

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: 'Link Tracker'
+    scrape_interval: 5s
+    metrics_path: /metrics
+    static_configs:
+      - targets: [ 'host.docker.internal:8081', 'host.docker.internal:8091' ]

--- a/scrapper/pom.xml
+++ b/scrapper/pom.xml
@@ -19,6 +19,26 @@
             <version>0.1</version>
         </dependency>
 
+        <!-- Metrics -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+        </dependency>
+
         <!-- Bucket4j -->
         <dependency>
             <groupId>com.giffing.bucket4j.spring.boot.starter</groupId>

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -75,3 +75,17 @@ springdoc:
     path: /swagger-ui
 
 link-check-interval: 10m
+
+management:
+  server:
+    port: 8081
+  endpoints:
+    web:
+      base-path: /
+      exposure:
+        include: health,info,prometheus
+      path-mapping:
+        prometheus: metrics
+  metrics:
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
Написал тесты, сделал отдельный [PR](https://github.com/Prohkit/java-backend-course-2-link-tracker/pull/15).  
PR в main [здесь](https://github.com/Prohkit/java-backend-course-2-link-tracker/pull/16).  
### Скрины для задачи 3:

- Количество используемой памяти в единицу времени с разбивкой по типу: jvm_memory_used_bytes;
- График скорости gc-аллокаций: jvm_gc_memory_allocated_bytes_total;
- Среднее время HTTP-ответа: http_server_requests_seconds_sum, http_server_requests_seconds_count.  
  
Все метрики:

![Все метрики](https://github.com/Prohkit/java-backend-course-2-link-tracker/assets/124617127/8d6c918c-326a-460c-89d9-4a7e3b67bcfc)  
Среднее время HTTP-ответа:

![Среднее время HTTP-ответа count](https://github.com/Prohkit/java-backend-course-2-link-tracker/assets/124617127/dd97122c-9032-4d1e-b414-cf7e211d45c4)  
### Скрины для задачи 4:  
Обновленные запросы выглядят так:  

- jvm_memory_used_bytes{application="$application"}
- jvm_gc_memory_allocated_bytes_total{application="$application"}
- http_server_requests_seconds_sum{application="$application"}
- http_server_requests_seconds_count{application="$application"}

Метрики для bot:  
![image](https://github.com/Prohkit/java-backend-course-2-link-tracker/assets/124617127/14585ea6-5820-4b0c-aef5-27081d7f05e5)  
![image](https://github.com/Prohkit/java-backend-course-2-link-tracker/assets/124617127/eb4439b6-db06-4b58-92b1-58ea146efe8f)


Метрики для scrapper:  
![image](https://github.com/Prohkit/java-backend-course-2-link-tracker/assets/124617127/8ef7adf1-62dc-4ccd-9ebc-f2200e6f0d9e)
![image](https://github.com/Prohkit/java-backend-course-2-link-tracker/assets/124617127/1840a248-c95c-4f1a-8be3-5a62324a1e34)

### Скрины для задачи 5:  
Добавил новую метрику - количество обработанных сообщений.  
Запрос: messages_processed_total{application="bot"}  
Скриншот метрики:  
![image](https://github.com/Prohkit/java-backend-course-2-link-tracker/assets/124617127/374cb56e-06aa-4128-9cb9-e2eabd68b053)
